### PR TITLE
Immersive portals fix

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,5 @@
 plugins {
-	id 'fabric-loom' version '0.2.7-SNAPSHOT'
+	id 'fabric-loom' version '0.5-SNAPSHOT'
 	id 'maven-publish'
 }
 
@@ -49,6 +49,7 @@ dependencies {
 	//KosmX - optifine debugger ingredients
 	//compile files("optifabric-1.1.0-beta2.jar")
 	//compile files("optifine_latest.jar")
+	compile files("immersive-portals-0.27-dev.jar")
 }
 
 processResources {

--- a/gradle.properties
+++ b/gradle.properties
@@ -6,7 +6,7 @@ yarn_mappings       = 1.16.2+build.12
 loader_version      = 0.9.1+build.205
 
 #Mod properties
-mod_version         = 1.3.0
+mod_version         = 1.3.1
 maven_group         = de.tr7zw
 archives_base_name  = FirstPersonMod
 

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 #Wed Jun 24 12:32:40 CEST 2020
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.5-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.6-bin.zip
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStorePath=wrapper/dists

--- a/src/main/java/de/tr7zw/firstperson/FirstPersonConfig.java
+++ b/src/main/java/de/tr7zw/firstperson/FirstPersonConfig.java
@@ -17,8 +17,8 @@ public class FirstPersonConfig implements ConfigData {
 	@ConfigEntry.Gui.Tooltip
 	public int sneakXOffset = 0;
 
-	@ConfigEntry.Gui.Tooltip
-	public boolean improvedCompatibility = true;
+	//@ConfigEntry.Gui.Tooltip
+	//public boolean improvedCompatibility = true;
 	
 	@ConfigEntry.Gui.Tooltip
 	public boolean enabledByDefault = true;
@@ -51,5 +51,6 @@ public class FirstPersonConfig implements ConfigData {
 
 	@ConfigEntry.Gui.Tooltip
 	public boolean forceActive = false;
-	
+	//Make the fixes force active. can solve problems in different renderers, and causing bugs
+	//on -> no OF compatibility, Hidden heads in Immersive portal mirrors...
 }

--- a/src/main/java/de/tr7zw/firstperson/FirstPersonConfig.java
+++ b/src/main/java/de/tr7zw/firstperson/FirstPersonConfig.java
@@ -48,5 +48,8 @@ public class FirstPersonConfig implements ConfigData {
 	
 	@ConfigEntry.Gui.Tooltip
 	public boolean dollLockedHead = false;
+
+	@ConfigEntry.Gui.Tooltip
+	public boolean forceActive = false;
 	
 }

--- a/src/main/java/de/tr7zw/firstperson/FirstPersonModelMod.java
+++ b/src/main/java/de/tr7zw/firstperson/FirstPersonModelMod.java
@@ -2,8 +2,10 @@ package de.tr7zw.firstperson;
 
 import net.fabricmc.fabric.api.client.event.lifecycle.v1.ClientTickEvents;
 import net.fabricmc.fabric.api.client.keybinding.v1.KeyBindingHelper;
+import net.minecraft.client.MinecraftClient;
 import net.minecraft.client.options.KeyBinding;
 import net.minecraft.client.util.math.MatrixStack;
+import net.minecraft.entity.Entity;
 import org.lwjgl.glfw.GLFW;
 
 import me.sargunvohra.mcmods.autoconfig1u.AutoConfig;
@@ -20,10 +22,13 @@ public class FirstPersonModelMod implements ModInitializer {
 	public static boolean isRenderingPlayer = false;
 	@Nullable
 	public static MatrixStack hideHeadWithMatrixStack = null;
+	@Nullable
+	public static MatrixStack paperDollStack = null; //Make force compatibility not hide paper doll
 	public static boolean enabled = true;
 	public static FirstPersonConfig config = null;
 	private static KeyBinding keyBinding;
 	private static boolean isHeld = false;
+
 
 	public static boolean fixBodyShadow(MatrixStack matrixStack){
 		return (!enabled || config.improvedCompatibility && !(hideHeadWithMatrixStack == matrixStack));
@@ -35,6 +40,10 @@ public class FirstPersonModelMod implements ModInitializer {
 	public static final float swimDownBodyOffset = 0.50f;
 	public static final float inVehicleBodyOffset = 0.20f;
 
+
+	public static boolean isFixActive(Entity player, MatrixStack matrices){
+		return MinecraftClient.getInstance() != null && MinecraftClient.getInstance().getCameraEntity() == player && (matrices == hideHeadWithMatrixStack || !config.forceActive && matrices != paperDollStack);
+	}
 	
 	@Override
 	public void onInitialize() {

--- a/src/main/java/de/tr7zw/firstperson/FirstPersonModelMod.java
+++ b/src/main/java/de/tr7zw/firstperson/FirstPersonModelMod.java
@@ -42,7 +42,7 @@ public class FirstPersonModelMod implements ModInitializer {
 
 
 	public static boolean isFixActive(Entity player, MatrixStack matrices){
-		return MinecraftClient.getInstance() != null && MinecraftClient.getInstance().getCameraEntity() == player && (matrices == hideHeadWithMatrixStack || !config.forceActive && matrices != paperDollStack);
+		return MinecraftClient.getInstance() != null && MinecraftClient.getInstance().getCameraEntity() == player && (matrices == hideHeadWithMatrixStack || config.forceActive && matrices != paperDollStack);
 	}
 	
 	@Override

--- a/src/main/java/de/tr7zw/firstperson/FirstPersonModelMod.java
+++ b/src/main/java/de/tr7zw/firstperson/FirstPersonModelMod.java
@@ -31,7 +31,7 @@ public class FirstPersonModelMod implements ModInitializer {
 
 
 	public static boolean fixBodyShadow(MatrixStack matrixStack){
-		return (!enabled || config.improvedCompatibility && !(hideHeadWithMatrixStack == matrixStack));
+		return (enabled && (config.forceActive || hideHeadWithMatrixStack == matrixStack));
 	}
 
 

--- a/src/main/java/de/tr7zw/firstperson/StaticMixinMethods.java
+++ b/src/main/java/de/tr7zw/firstperson/StaticMixinMethods.java
@@ -21,7 +21,7 @@ public class StaticMixinMethods {
 	public static Vec3d offset;
 
 	public static Vec3d getPositionOffset(AbstractClientPlayerEntity var1, Vec3d defValue, MatrixStack matrices) {
-		if(var1 == MinecraftClient.getInstance().getCameraEntity() && MinecraftClient.getInstance().player.isSleeping() || FirstPersonModelMod.fixBodyShadow(matrices))return defValue;
+		if(var1 == MinecraftClient.getInstance().getCameraEntity() && MinecraftClient.getInstance().player.isSleeping() || !FirstPersonModelMod.fixBodyShadow(matrices))return defValue;
 		double x,y,z = x = y = z = 0;
 		AbstractClientPlayerEntity abstractClientPlayerEntity_1;
 		double realYaw;

--- a/src/main/java/de/tr7zw/firstperson/StaticMixinMethods.java
+++ b/src/main/java/de/tr7zw/firstperson/StaticMixinMethods.java
@@ -33,7 +33,7 @@ public class StaticMixinMethods {
 			abstractClientPlayerEntity_1 = null;
 			return defValue;
 		}
-		if (abstractClientPlayerEntity_1 != null && (!abstractClientPlayerEntity_1.isMainPlayer() || MinecraftClient.getInstance().getCameraEntity() == abstractClientPlayerEntity_1)) {
+		if (!abstractClientPlayerEntity_1.isMainPlayer() || MinecraftClient.getInstance().getCameraEntity() == abstractClientPlayerEntity_1) {
 			float bodyOffset;
 			if(abstractClientPlayerEntity_1.isSneaking()){
 				bodyOffset = FirstPersonModelMod.sneakBodyOffset + (FirstPersonModelMod.config.sneakXOffset / 100f);

--- a/src/main/java/de/tr7zw/firstperson/mixins/CameraMixin.java
+++ b/src/main/java/de/tr7zw/firstperson/mixins/CameraMixin.java
@@ -1,0 +1,20 @@
+package de.tr7zw.firstperson.mixins;
+
+import de.tr7zw.firstperson.StaticMixinMethods;
+import net.minecraft.client.render.Camera;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Shadow;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
+
+@Mixin(Camera.class)
+public class CameraMixin {
+    @Shadow private boolean thirdPerson;
+
+    @Inject(method = "isThirdPerson", at = @At("HEAD"), cancellable = true)
+    private void CameraInject(CallbackInfoReturnable<Boolean> cir){
+        if(!this.thirdPerson)cir.setReturnValue(StaticMixinMethods.isThirdPerson(false));
+        //cir.setReturnValue(true);
+    }
+}

--- a/src/main/java/de/tr7zw/firstperson/mixins/FishingBobberRendererMixin.java
+++ b/src/main/java/de/tr7zw/firstperson/mixins/FishingBobberRendererMixin.java
@@ -28,11 +28,11 @@ public class FishingBobberRendererMixin {
 
     private Vec3d offsetvec3d = Vec3d.ZERO; //to not create @Nullable
 
-    private Vec3d getPositionOffset(PlayerEntity var1) {
+    private Vec3d getPositionOffset(PlayerEntity var1, MatrixStack matrices) {
         double x,y,z = x = y = z = 0;
         PlayerEntity abstractClientPlayerEntity_1;
         Float realYaw = 0f;
-        if(var1 == (PlayerEntity) MinecraftClient.getInstance().player && doCorrect()) {
+        if(FirstPersonModelMod.isFixActive(var1, matrices) && doCorrect()) {
             abstractClientPlayerEntity_1 = (PlayerEntity) var1;
             realYaw = MathHelper.lerpAngleDegrees(MinecraftClient.getInstance().getTickDelta(), abstractClientPlayerEntity_1.prevYaw, abstractClientPlayerEntity_1.yaw);
         }else {
@@ -82,7 +82,7 @@ public class FishingBobberRendererMixin {
 
     @Inject(method = "render", at = @At("HEAD"))
     private void calcOffset(FishingBobberEntity fishingBobberEntity, float f, float g, MatrixStack matrixStack, VertexConsumerProvider vertexConsumerProvider, int i, CallbackInfo info){
-        this.offsetvec3d = getPositionOffset(fishingBobberEntity.getOwner());
+        this.offsetvec3d = getPositionOffset(fishingBobberEntity.getOwner(), matrixStack);
     }
 
     @Redirect(method = "render", at = @At(

--- a/src/main/java/de/tr7zw/firstperson/mixins/HeadFeatureRendererMixin.java
+++ b/src/main/java/de/tr7zw/firstperson/mixins/HeadFeatureRendererMixin.java
@@ -25,7 +25,7 @@ public abstract class HeadFeatureRendererMixin<T extends LivingEntity, M extends
 
 	@Inject(at = @At("HEAD"), method = "render", cancellable = true)
 	protected void render(MatrixStack matrixStack_1, VertexConsumerProvider vertexConsumerProvider_1, int int_1, T livingEntity_1, float float_1, float float_2, float float_3, float float_4, float float_5, float float_6, CallbackInfo info) {
-		if(livingEntity_1 == MinecraftClient.getInstance().getCameraEntity() && FirstPersonModelMod.hideHeadWithMatrixStack == matrixStack_1) {
+		if(FirstPersonModelMod.isFixActive(livingEntity_1, matrixStack_1)) {
 	        info.cancel();
 		}
 	}

--- a/src/main/java/de/tr7zw/firstperson/mixins/InGameHudMixin.java
+++ b/src/main/java/de/tr7zw/firstperson/mixins/InGameHudMixin.java
@@ -52,6 +52,7 @@ public class InGameHudMixin {
 		RenderSystem.translatef((float) i, (float) j, 1050.0F);
 		RenderSystem.scalef(1.0F, 1.0F, -1.0F);
 		MatrixStack matrixStack = new MatrixStack();
+		FirstPersonModelMod.paperDollStack = matrixStack; // To not hide head if rendering this
 		matrixStack.translate(0.0D, 0.0D, 1000.0D);
 		matrixStack.scale((float) k, (float) k, (float) k);
 		Quaternion quaternion = Vector3f.POSITIVE_Z.getDegreesQuaternion(180.0F);

--- a/src/main/java/de/tr7zw/firstperson/mixins/PlayerRenderMixin.java
+++ b/src/main/java/de/tr7zw/firstperson/mixins/PlayerRenderMixin.java
@@ -42,7 +42,7 @@ public abstract class PlayerRenderMixin extends LivingEntityRenderer<AbstractCli
 	))
 	private void setModelPoseRedirect(PlayerEntityRenderer playerEntityRenderer, AbstractClientPlayerEntity abstractClientPlayerEntity, AbstractClientPlayerEntity abstractClientPlayerEntity_1, float f, float g, MatrixStack matrixStack, VertexConsumerProvider vertexConsumerProvider, int i) {
 		setModelPose(abstractClientPlayerEntity);
-		if(abstractClientPlayerEntity == MinecraftClient.getInstance().getCameraEntity() && FirstPersonModelMod.hideHeadWithMatrixStack == matrixStack) {
+		if(FirstPersonModelMod.isFixActive(abstractClientPlayerEntity, matrixStack)) {
 			this.setModelPose(abstractClientPlayerEntity);
 			PlayerEntityModel<AbstractClientPlayerEntity> playerEntityModel_1 = (PlayerEntityModel)this.getModel();
 			playerEntityModel_1.head.visible = false;

--- a/src/main/java/de/tr7zw/firstperson/mixins/WorldRendererMixin.java
+++ b/src/main/java/de/tr7zw/firstperson/mixins/WorldRendererMixin.java
@@ -24,7 +24,7 @@ public class WorldRendererMixin {
 	@Inject(at = @At("HEAD"), method = "renderEntity")
 	private void renderEntity(Entity entity_1, double double_1, double double_2, double double_3, float float_1, MatrixStack matrixStack_1, VertexConsumerProvider vertexConsumerProvider_1, CallbackInfo info) {
 		if (FirstPersonModelMod.hideNextHeadArmor) FirstPersonModelMod.hideNextHeadArmor = false;
-		if (entity_1 == MinecraftClient.getInstance().getCameraEntity() && FirstPersonModelMod.hideHeadWithMatrixStack == matrixStack_1) FirstPersonModelMod.hideNextHeadArmor = true; 	//if I don't wear any armor head then another helmet will be hidden without this
+		if (FirstPersonModelMod.isFixActive(entity_1, matrixStack_1)) FirstPersonModelMod.hideNextHeadArmor = true; 	//if I don't wear any armor head then another helmet will be hidden without this
 
 		if(MinecraftClient.getInstance().options.getPerspective() != Perspective.FIRST_PERSON)return;
 		if(entity_1 instanceof AbstractClientPlayerEntity) {

--- a/src/main/java/de/tr7zw/firstperson/mixins/WorldRendererMixin.java
+++ b/src/main/java/de/tr7zw/firstperson/mixins/WorldRendererMixin.java
@@ -2,18 +2,16 @@ package de.tr7zw.firstperson.mixins;
 
 import de.tr7zw.firstperson.StaticMixinMethods;
 import net.minecraft.client.options.Perspective;
-import net.minecraft.client.render.Camera;
+import net.minecraft.client.render.*;
+import net.minecraft.util.math.Matrix4f;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
-import org.spongepowered.asm.mixin.injection.Redirect;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 
 import de.tr7zw.firstperson.FirstPersonModelMod;
 import net.minecraft.client.MinecraftClient;
 import net.minecraft.client.network.AbstractClientPlayerEntity;
-import net.minecraft.client.render.VertexConsumerProvider;
-import net.minecraft.client.render.WorldRenderer;
 import net.minecraft.client.util.math.MatrixStack;
 import net.minecraft.entity.Entity;
 import net.minecraft.entity.player.PlayerEntity;
@@ -33,16 +31,13 @@ public class WorldRendererMixin {
 		}
 	}
 
-	@Redirect(method = "Lnet/minecraft/client/render/WorldRenderer;render(Lnet/minecraft/client/util/math/MatrixStack;FJZLnet/minecraft/client/render/Camera;Lnet/minecraft/client/render/GameRenderer;Lnet/minecraft/client/render/LightmapTextureManager;Lnet/minecraft/util/math/Matrix4f;)V", at = @At(
+	@Inject(method = "Lnet/minecraft/client/render/WorldRenderer;render(Lnet/minecraft/client/util/math/MatrixStack;FJZLnet/minecraft/client/render/Camera;Lnet/minecraft/client/render/GameRenderer;Lnet/minecraft/client/render/LightmapTextureManager;Lnet/minecraft/util/math/Matrix4f;)V", at = @At(
 			value = "INVOKE",
 			target = "Lnet/minecraft/client/render/Camera;isThirdPerson()Z"
 	))
-	private boolean redirect(Camera camera, MatrixStack matrices){
-		if(StaticMixinMethods.isThirdPerson(camera.isThirdPerson())){
+	private void redirect(MatrixStack matrices, float tickDelta, long limitTime, boolean renderBlockOutline, Camera camera, GameRenderer gameRenderer, LightmapTextureManager lightmapTextureManager, Matrix4f matrix4f, CallbackInfo ci){
+		if(StaticMixinMethods.isThirdPerson(MinecraftClient.getInstance().options.getPerspective() != Perspective.FIRST_PERSON)) {
 			FirstPersonModelMod.hideHeadWithMatrixStack = matrices;
-			return true;
 		}
-		else return camera.isThirdPerson();
 	}
-	
 }

--- a/src/main/resources/firstperson.mixins.json
+++ b/src/main/resources/firstperson.mixins.json
@@ -10,6 +10,7 @@
 	"PlayerRenderMixin",
 	"ArmorRendererMixin",
 	"GameRendererMixin",
+    "CameraMixin",
   "WorldRendererMixin",
   "FishingBobberRendererMixin",
   "RenderDispatcherMixin",


### PR DESCRIPTION
I've made some cleaning (just a bit), The isThirdPerson modify is moved back to Camera but the check MatrixStack set still in the WorldRenderer, (Redirect -> Inject)

ForceActive Make the fix to happen every render (can solve different render engines incompatibility but create more issues)
As soon as Canvas comes out to 1.16.2 I will solve the incompatibility.
Still compatible with OF
[I told, there will be an Optifabric 1.16.2](https://github.com/Andrews54757/OptiFabric-updated)